### PR TITLE
Khadath's trap no longer blocks movement if he is standing directly on it.

### DIFF
--- a/lib/khadath.rb
+++ b/lib/khadath.rb
@@ -216,7 +216,7 @@ class Khadath < Character
   end
 
   def blocked_spaces(direct_movement)
-    if !direct_movement && @trap
+    if !direct_movement && @trap && @trap != position
       if @trap < @opponent.position
         return [@trap-1] + super
       elsif @trap > @opponent.position


### PR DESCRIPTION
@AKilbo @akanter 

This breaks at least one existing game (but I think just that). Do you guys agree that this is the right way to evaluate the situation? The issue is that the trap says "if an opponents movement brings you onto the gate trap, that movement immediately stops," but the way its implemented says if you're on one side of the trap, all spaces on the other side are blocked; thus even if khadath is on his trap, it still blocks movement past.

I think we should merge this.
